### PR TITLE
BugFix: instance merging fails in some cases

### DIFF
--- a/koi_api/resources/instance.py
+++ b/koi_api/resources/instance.py
@@ -852,15 +852,15 @@ class APIInstanceMerge(BaseResource):
 
         # add the new descriptors to the merged instance
         for key, values in new_descriptors.items():
-            new_desc = ORMInstanceDescriptor()
-            new_desc.descriptor_key = key
-            new_desc.descriptor_instance_id = instance.instance_id
-            new_desc.descriptor_uuid = uuid1()
+            for value in values:
+                new_desc = ORMInstanceDescriptor()
+                new_desc.descriptor_key = key
+                new_desc.descriptor_instance_id = instance.instance_id
+                new_desc.descriptor_uuid = uuid1().bytes
 
-            file_pers = persistence.store_file(values)
+                file_pers = persistence.store_file(value)
 
-            new_desc.descriptor_file_id = file_pers.file_id
-            db.session.add(file_pers)
-            db.session.add(new_desc)
+                new_desc.descriptor_file_id = file_pers.file_id
+                db.session.add(new_desc)
 
         db.session.commit()

--- a/tests/instances_test.py
+++ b/tests/instances_test.py
@@ -32,7 +32,10 @@ def test_instance_merging(testserver):
     inst2.finalized = True
 
     # give them some descriptors
-    # TODO
+    inst1.descriptors["c"].append("1")
+    inst1.descriptors["c"].append("2")
+    inst2.descriptors["c"].append("2")
+    inst2.descriptors["c"].append("3")
 
     # create samples for these instances
     sample1 = inst1.new_sample()

--- a/tests/instances_test.py
+++ b/tests/instances_test.py
@@ -37,6 +37,9 @@ def test_instance_merging(testserver):
     inst2.descriptors["c"].append("2")
     inst2.descriptors["c"].append("3")
 
+    inst1.descriptors["a"].append("1")
+    inst2.descriptors["b"].append("2")
+
     # create samples for these instances
     sample1 = inst1.new_sample()
     sample2 = inst2.new_sample()
@@ -66,6 +69,16 @@ def test_instance_merging(testserver):
     # merge and get the samples
     inst3.merge([inst1, inst2])
     samples = list(inst3.get_samples())
+
+    # get the descriptors after merging
+    desc_a = [x.raw.decode() for x in inst3.descriptors["a"]]
+    desc_b = [x.raw.decode() for x in inst3.descriptors["b"]]
+    desc_c = [x.raw.decode() for x in inst3.descriptors["c"]]
+
+    # check if we merged the descriptor correctly
+    assert desc_a == ["1"]
+    assert desc_b == ["2"]
+    assert desc_c == ["1", "2", "3"]
 
     # the merged instance schould have two samples
     assert len(samples) == 2


### PR DESCRIPTION
We observed the merging failing if descriptors are set. Therefore the tests should include setting some descriptors.